### PR TITLE
Dynamically determine Tenant ID from Resource URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,6 +209,12 @@
         "@types/node": "*"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",
@@ -237,6 +243,31 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
+    "@types/request": {
+      "version": "2.48.3",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/sinon": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
@@ -252,6 +283,12 @@
         "@types/chai": "*",
         "@types/sinon": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
     },
     "adal-node": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/google-protobuf": "^3.2.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.4",
+    "@types/request": "^2.48.3",
     "chai": "^4.2.0",
     "check-engine": "^1.8.1",
     "grpc-tools": "^1.7.3",
@@ -60,6 +61,7 @@
     "dynamics-web-api": "^1.5.10",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",
+    "request": "^2.88.0",
     "ts-node": "^8.3.0"
   }
 }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -1,6 +1,7 @@
 import * as DynamicsWebApi from 'dynamics-web-api';
 import * as AuthenticationContext from 'adal-node';
 import * as grpc from 'grpc';
+import * as request from 'request';
 import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
 import { EntityAwareMixin } from './mixins/entity-aware';
@@ -64,21 +65,47 @@ class ClientWrapper {
    */
   // tslint:disable-next-line:max-line-length
   constructor(auth: grpc.Metadata, clientConstructor = DynamicsWebApi, adal = AuthenticationContext) {
-    const authContext = adal.AuthenticationContext;
-    const adalContext = new authContext(`https://login.microsoftonline.com/${auth.get('tenantId')[0]}/oauth2/token`);
-    function acquireToken(dynamicsWebApiCallback) {
-      adalContext.acquireTokenWithClientCredentials(
-        auth.get('resource')[0].toString(),
-        auth.get('clientId')[0].toString(),
-        auth.get('clientSecret')[0].toString(),
-        (error, token) => {
-          dynamicsWebApiCallback(token);
-          this.clientReady = Promise.resolve(true);
+    // Client instantiation is async; all steps await this.clientReady.
+    this.clientReady = new Promise(async (clientIsready, clientError) => {
+      // First, get the tenant ID dynamically using a "bearer challenge"
+      const tenantId = await new Promise((resolve) => {
+        request(`${auth.get('resource')[0].toString()}/api/data`, (err, res) => {
+          if (err) {
+            return clientError(err);
+          }
+          if (!res.headers.hasOwnProperty('www-authenticate')) {
+            return clientError(Error('Authentication error: unable to retrieve tenant ID using resource URL.'));
+          }
+
+          const matches = /\.microsoftonline\.com\/([a-zA-Z0-9-]+)\//gi.exec(res.headers['www-authenticate']);
+          if (!matches || !matches[1]) {
+            return clientError('Authentication error: unable to extract tenant ID from bearer challenge.');
+          }
+
+          resolve(matches[1]);
         });
-    }
-    this.client = new clientConstructor({
-      webApiUrl: `${auth.get('resource')}/api/data/v9.0/`,
-      onTokenRefresh: acquireToken,
+      });
+
+      // Then, set the client using the given tenant ID, resource, etc.
+      const authContext = adal.AuthenticationContext;
+      const adalContext = new authContext(`https://login.microsoftonline.com/${tenantId}/oauth2/token`);
+      function acquireToken(dynamicsWebApiCallback) {
+        adalContext.acquireTokenWithClientCredentials(
+          auth.get('resource')[0].toString(),
+          auth.get('clientId')[0].toString(),
+          auth.get('clientSecret')[0].toString(),
+          (error, token) => {
+            dynamicsWebApiCallback(token);
+          },
+        );
+      }
+      this.client = new clientConstructor({
+        webApiUrl: `${auth.get('resource')[0].toString()}/api/data/v9.0/`,
+        onTokenRefresh: acquireToken,
+      });
+
+      // Resolve this.clientReady.
+      clientIsready(true);
     });
   }
 }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -24,7 +24,7 @@ class ClientWrapper {
   public static expectedAuthFields: Field[] = [
     {
       field: 'resource',
-      type: FieldDefinition.Type.STRING,
+      type: FieldDefinition.Type.URL,
       description: 'Resource URL',
     },
     {

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -23,11 +23,6 @@ class ClientWrapper {
    */
   public static expectedAuthFields: Field[] = [
     {
-      field: 'tenantId',
-      type: FieldDefinition.Type.STRING,
-      description: 'Tenant Id',
-    },
-    {
       field: 'resource',
       type: FieldDefinition.Type.STRING,
       description: 'Resource URL',

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -61,7 +61,7 @@ class ClientWrapper {
   // tslint:disable-next-line:max-line-length
   constructor(auth: grpc.Metadata, clientConstructor = DynamicsWebApi, adal = AuthenticationContext) {
     // Client instantiation is async; all steps await this.clientReady.
-    this.clientReady = new Promise(async (clientIsready, clientError) => {
+    this.clientReady = new Promise(async (clientIsReady, clientError) => {
       // First, get the tenant ID dynamically using a "bearer challenge"
       const tenantId = await new Promise((resolve) => {
         request(`${auth.get('resource')[0].toString()}/api/data`, (err, res) => {
@@ -100,7 +100,7 @@ class ClientWrapper {
       });
 
       // Resolve this.clientReady.
-      clientIsready(true);
+      clientIsReady(true);
     });
   }
 }

--- a/test/core/cog.ts
+++ b/test/core/cog.ts
@@ -42,9 +42,6 @@ describe('Cog:GetManifest', () => {
       const r: any = authFields.filter(a => a.key === 'resource')[0];
       expect(r.type).to.equal(FieldDefinition.Type.STRING);
       expect(r.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-      const ti: any = authFields.filter(a => a.key === 'tenantId')[0];
-      expect(ti.type).to.equal(FieldDefinition.Type.STRING);
-      expect(ti.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
       const ci: any = authFields.filter(a => a.key === 'clientId')[0];
       expect(ci.type).to.equal(FieldDefinition.Type.STRING);
       expect(ci.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);

--- a/test/core/cog.ts
+++ b/test/core/cog.ts
@@ -40,7 +40,7 @@ describe('Cog:GetManifest', () => {
 
       // Useragent auth field
       const r: any = authFields.filter(a => a.key === 'resource')[0];
-      expect(r.type).to.equal(FieldDefinition.Type.STRING);
+      expect(r.type).to.equal(FieldDefinition.Type.URL);
       expect(r.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
       const ci: any = authFields.filter(a => a.key === 'clientId')[0];
       expect(ci.type).to.equal(FieldDefinition.Type.STRING);


### PR DESCRIPTION
- Removes Tenant ID from auth fields array.
- Dynamically retrieves tenant ID from bearer challenge [per recommendation here](https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/authenticate-oauth#discover-the-authority-at-run-time)