### PR TITLE
Fixed steps from returning invalid pass/fail message because the oper…

### DIFF
--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -46,9 +46,9 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
       const records = await this.client.retrieveMultiple(request);
       const result = records.find((lead: any) => lead['emailaddress1'] === email);
       if (this.compare(operator, result[field], expectedValue)) {
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [field, expectedValue]);
+        return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue]);
       } else {
-        return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.fail(this.operatorFailMessages[operator], [
           field,
           expectedValue,
           result[field],


### PR DESCRIPTION
The `util` had a change in determining proper `pass/fail` messages as seen on:

https://github.com/run-crank/typescript-cog-utilities/blob/master/src/utils/compare.ts#L4

There are steps affected that still has the `.replace(/\s/g, '').toLowerCase()` code which removes all space and then therefore cannot be mapped to the updated pass fail messages in the `util` (which now contains space)