### PR TITLE
Removed stringification for values passed when asserting

### DIFF
--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -86,7 +86,7 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
         leadRecord = this.createRecord(lead);
       }
 
-      const result = this.assert(operator, String(actualValue), String(expectedValue), field);
+      const result = this.assert(operator, actualValue, expectedValue, field);
 
       return result.valid ? this.pass(result.message, [], [leadRecord])
         : this.fail(result.message, [], [leadRecord]);


### PR DESCRIPTION
#What's changed?
* Removed `String` constructor calls to stringify values passed to the `util.assert` function

Reason: `null` values are potentially asserted as `'null'` than actual null values which causes some operators such as `Set Operator` to fail unexpectedly