### PR TITLE
PII suppresion in step messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,9 +182,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.0.tgz",
-      "integrity": "sha512-gEDbF8hl99dFtg3kN7hEnM4E82RAnX3+8HATXbPWiVIr7zop5SDIL6mlk/QxpHecOlYgM4jebHJ+dqCTdotqVg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.1.tgz",
+      "integrity": "sha512-U9YS6zsu7/PCtJl6/PZRcnS8Dh3r4CWLyAg01MhUp7e5rkW2OXZUdosO0RcRYfQHWjs6flz8R2ATTo7TD/jsrQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"
@@ -1431,9 +1431,9 @@
       }
     },
     "csv-string": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.0.tgz",
-      "integrity": "sha512-67UM45fosQvvh+HUvC8iNgg2B4UHWJ5Qud7TWy1EcbIQ9levAFKWudMk2k8U3LgXZP/Drr6eBwBwbSWq2N8HZA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.5.0",
+    "@run-crank/utilities": "^0.5.1",
     "adal-node": "^0.2.1",
     "chai-as-promised": "^7.1.1",
     "dynamics-web-api": "^1.5.10",

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -85,8 +85,8 @@ export abstract class BaseStep {
     return stepDefinition;
   }
 
-  assert(operator: string, actualValue: string, value: string, field: string): util.AssertionResult {
-    return util.assert(operator, actualValue, value, field);
+  assert(operator: string, actualValue: string, value: string, field: string, piiLevel: string = null): util.AssertionResult {
+    return util.assert(operator, actualValue, value, field, piiLevel);
   }
 
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {

--- a/src/steps/contact/contact-field-equals.ts
+++ b/src/steps/contact/contact-field-equals.ts
@@ -90,7 +90,7 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
         contactRecord = this.createRecord(contact);
       }
 
-      const result = this.assert(operator, actualValue, expectedValue, field);
+      const result = this.assert(operator, actualValue, expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [contactRecord])
         : this.fail(result.message, [], [contactRecord]);

--- a/src/steps/lead/lead-field-equals.ts
+++ b/src/steps/lead/lead-field-equals.ts
@@ -86,7 +86,7 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
         leadRecord = this.createRecord(lead);
       }
 
-      const result = this.assert(operator, actualValue, expectedValue, field);
+      const result = this.assert(operator, actualValue, expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [leadRecord])
         : this.fail(result.message, [], [leadRecord]);


### PR DESCRIPTION
- Update typescript cog utilities
- Some step messages will have PII removed if a "__piiSuppressionLevel" is passed in the stepData